### PR TITLE
Generator Option Groups UI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Codotype
+Copyright (c) 2019 Codotype
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # codotype-web
 Codotype Web Client Application
+
+
+TODO - update to use vue-cli-service
+TODO - remove unncessary linting & webpack dotfiles
+TODO - remove unused test directory
+TODO - remove unused Dockerfile (archive elsewhere)

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="icon" type="image/png" href="/static/favicon.png">
 
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://unpkg.com/font-awesome-animation@0.2.1/dist/font-awesome-animation.min.css">
+    <!-- <link rel="stylesheet" href="https://unpkg.com/font-awesome-animation@0.2.1/dist/font-awesome-animation.min.css"> -->
   </head>
   <body>
     <div id="app"></div>

--- a/src/components/GeneratorMenu.vue
+++ b/src/components/GeneratorMenu.vue
@@ -12,20 +12,18 @@
         <b-nav-item id="project-header">What's Codotype?</b-nav-item>
       </b-navbar-nav>
 
-      <b-navbar-nav class="ml-auto" v-if="!buildLoading && !buildFinished">
+      <b-navbar-nav class="ml-auto">
         <b-nav-form>
 
           <HelpButton class='mr-2' size='lg' tooltipPlacement="bottom" tour='buildSteps' />
 
           <b-button
             size='lg'
-            :disabled="disableGenerateButton"
             id="generate-button"
             variant="success"
             @click="generateCodebase()"
             v-b-tooltip.hover.bottom :title='"Click here to generate code"'
           >
-            <!-- <i class="fa fa-fw fa-code"></i> -->
             <i class="fa fa-fw fa-spin fa-cog"></i>
             Generate Code
           </b-button>

--- a/src/modules/build/pages/new.vue
+++ b/src/modules/build/pages/new.vue
@@ -189,6 +189,9 @@ import { mapGetters, mapMutations, mapActions } from 'vuex'
 import marked from 'marked'
 
 export default {
+  metaInfo: {
+    title: 'Build'
+  },
   components: {
     LoadingBuild,
     MoreInfoLink,

--- a/src/modules/relation/store/constants.js
+++ b/src/modules/relation/store/constants.js
@@ -6,7 +6,6 @@ export const DEFAULT_RELATION = {
   type: 'BELONGS_TO', // Moved from datatypeOptions.relationType
   required: false,
   // QUESTION - add schema id here?
-  generate_reverse: true,
   related_schema_id: '',
   reverse_relation_id: '',
   as: '',


### PR DESCRIPTION
Added UI for interacting with a generator's `option_groups` configuration schema - starting to take shape

![screenshot from 2019-01-19 23-38-24](https://user-images.githubusercontent.com/4616233/51435353-6a1a3600-1c43-11e9-97a5-70ae787a6658.png)
![screenshot from 2019-01-19 23-38-14](https://user-images.githubusercontent.com/4616233/51435354-6ab2cc80-1c43-11e9-99ce-07ba05559c19.png)
