### PR TITLE
Added _redirects for netlify proxy, tweaked robots.txt

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+/api/*  https://codotype.io/api/:splat  200
+/*      /index.html                     200

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,2 @@
 User-Agent: *
 Disallow:
-Allow: /about


### PR DESCRIPTION
Site can now be deployed to Netlify with all server-side operations proxied through `https://codotype.io/api`